### PR TITLE
Issue #48-update links in navbar to NPT only sites.

### DIFF
--- a/templates/includes/navbar.html
+++ b/templates/includes/navbar.html
@@ -58,10 +58,10 @@
                 Links
             </a>
             <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDropdown">
-              <li><a class="dropdown-item" href="https://www.cbr.washington.edu/dart" target="_blank">DART</a></li>
               <li><a class="dropdown-item" href="https://npt-cdms.nezperce.org/login.html#!/login" target="_blank">CDMS</a></li>
               <li><a class="dropdown-item" href="https://nptfisheries.shinyapps.io/kus-data/" target="_blank">Kus Data</a></li>
-              <li><a class="dropdown-item" href="https://nptfisheries.shinyapps.io/PITtrackR/" target="_blank">PitTrackR</a></li>
+              <li><a class="dropdown-item" href="https://nezperce.org/" target="_blank">Nez Perce Tribe</a></li>
+              <li><a class="dropdown-item" href="https://nezperce.org/contact/employment/" target="_blank">NPT Employement Opportunities</a></li>
             </ul>
           </li>
 


### PR DESCRIPTION
Links have been updated to display CDMS, Kus, NPT home, and NPT Employment Opportunities sites.